### PR TITLE
Feature/support multiple ppas and multiple series

### DIFF
--- a/src/ubuntu_package_status/ubuntu_package_status.py
+++ b/src/ubuntu_package_status/ubuntu_package_status.py
@@ -253,7 +253,14 @@ def get_status_for_all_packages(package_config, package_architectures=["amd64"])
     ),
 )
 @click.option(
-    "--series", help='the Ubuntu series eg. "20.04" or "focal"', required=False, default=None
+    "--series",
+    "series",
+    multiple=True,
+    help="The Ubuntu series eg. '20.04' or 'focal'."
+    "This option can be specified multiple times.",
+    required=False,
+    default=[],
+
 )
 @click.option(
     "--package-name", "package_names", multiple=True, help='Binary package name', required=False, default=[]
@@ -293,7 +300,7 @@ def get_status_for_all_packages(package_config, package_architectures=["amd64"])
 def ubuntu_package_status(
     ctx, config, series, package_names, logging_level, config_skeleton, output_format, package_architectures
 ):
-    # type: (Dict, Text, Text, bool, Text, Text) -> None
+    # type: (Dict, List[Text], Text, bool, Text, Text) -> None
     """
     Watch specified packages in the ubuntu archive for transition between
     archive pockets. Useful when waiting for a package update to be published.
@@ -320,15 +327,14 @@ def ubuntu_package_status(
                 print(output)
                 exit(0)
     else:
+        # create a dict for each series specified
         package_config = {
-            'ubuntu-versions':
-                {
-                    series:
-                        {
-                            'packages': package_names
-                        }
-                }
+            'ubuntu-versions': {}
         }
+        for individual_series in series:
+            package_config['ubuntu-versions'][individual_series] = {
+                'packages': package_names
+            }
 
     # Initialise all package version
     package_status = get_status_for_all_packages(package_config, package_architectures)


### PR DESCRIPTION
* feat: Add support for querying one of more PPAs for package version/publication status

Useful when tracking package publication in PPAs.

For example to track the `linux-gcp` kernel in focal and jammy in all archive pockets BUT also in the
`canonical-kernel-team/proposed2` `canonical-kernel-team/proposed` PPAs where proposed kernels are staged.

```
$ ubuntu_package_status.py --series=focal --series=jammy --package-name=linux-gcp --package-architecture=amd64 --ppa ppa:canonical-kernel-team/proposed2 --ppa ppa:canonical-kernel-team/proposed
focal
        linux-gcp
                Release/main amd64 5.4.0.1009.9 @ 14 Apr 2020, 18:29:46 (2 years ago)
                Proposed/main amd64 5.15.0.1032.40~20.04.1 @ 11 Apr 2023, 16:54:21 (2 days ago)
                Security/main amd64 5.15.0.1031.38~20.04.1 @ 27 Mar 2023, 20:38:59 (17 days ago)
                Updates/main amd64 5.15.0.1031.38~20.04.1 @ 27 Mar 2023, 11:44:59 (18 days ago)
                ppa:canonical-kernel-team/proposed2/main amd64 5.15.0.1027.34~20.04.1 @ 10 Jan 2023, 10:56:41 (3 months ago)
                ppa:canonical-kernel-team/proposed/main amd64 5.15.0.1032.40~20.04.1 @ 11 Apr 2023, 17:05:04 (2 days ago)
jammy
        linux-gcp
                Release/main amd64 5.15.0.1003.4 @ 6 Apr 2022, 13:09:00 (1 year, 7 days ago)
                Proposed/main amd64 5.15.0.1032.27 @ 31 Mar 2023, 18:19:32 (13 days ago)
                Security/main amd64 5.15.0.1031.26 @ 27 Mar 2023, 20:52:59 (17 days ago)
                Updates/main amd64 5.15.0.1031.26 @ 27 Mar 2023, 11:44:59 (18 days ago)
                ppa:canonical-kernel-team/proposed2/main amd64 5.15.0.1027.22 @ 9 Jan 2023, 21:10:27 (3 months ago)
                ppa:canonical-kernel-team/proposed/main amd64 5.15.0.1032.27 @ 31 Mar 2023, 18:52:28 (13 days ago)
```
* feat: Add support for specifying multiple series when querying archive

Useful for if you wish to check linux-gcp in focal and jammy without having to create a full config for example

```
$ ubuntu_package_status.py --series=focal --series=jammy --package-name=linux-gcp --package-architecture=amd64
focal
        linux-gcp
                Release/main amd64 5.4.0.1009.9 @ 14 Apr 2020, 18:29:46 (2 years ago)
                Proposed/main amd64 5.15.0.1032.40~20.04.1 @ 11 Apr 2023, 16:54:21 (2 days ago)
                Security/main amd64 5.15.0.1031.38~20.04.1 @ 27 Mar 2023, 20:38:59 (17 days ago)
                Updates/main amd64 5.15.0.1031.38~20.04.1 @ 27 Mar 2023, 11:44:59 (18 days ago)
jammy
        linux-gcp
                Release/main amd64 5.15.0.1003.4 @ 6 Apr 2022, 13:09:00 (1 year, 7 days ago)
                Proposed/main amd64 5.15.0.1032.27 @ 31 Mar 2023, 18:19:32 (13 days ago)
                Security/main amd64 5.15.0.1031.26 @ 27 Mar 2023, 20:52:59 (17 days ago)
                Updates/main amd64 5.15.0.1031.26 @ 27 Mar 2023, 11:44:59 (18 days ago)

```
