### PR TITLE
feat: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest stable channel release of this snap is supported.
+
+## What qualifies as a security issue
+
+Any issue which affects the confidentiality, integrity, or availability of
+information, systems, or users using this documentation should be reported.
+
+## Reporting a Vulnerability
+To report a security issue, file a
+[Private Security Report](https://github.com/canonical/ubuntu-package-status/security/advisories/new)
+with a description of the issue, the steps you took to create the issue,
+affected versions, and, if known, mitigations for the issue.
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy)
+contains more information about what you can expect when you contact us and
+what we expect from you.


### PR DESCRIPTION
Adding the security.md to improve the repo's security advisory posture and comply with best practices.